### PR TITLE
ci: test macos-14 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-14
           - macos-13
           - macos-latest
           - windows-latest
@@ -187,6 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - macos-14
           - macos-13
           - macos-latest
     steps:


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/