### PR TITLE
ci: disable build summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ on:
 
 env:
   DOCKER_VERSION: v27.3.1
+  DOCKER_BUILD_SUMMARY: false
 
 jobs:
   main:


### PR DESCRIPTION
This is not necessary in this workflow where we just want to test a simple build.